### PR TITLE
Update registry interface

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -4,6 +4,16 @@ Modules extend the functionality of Accounts in different ways. Initial modules 
 
 [General Types](../manager/README.md#general-types)
 
+## Module Types
+
+Each module is assigned a value that represents the type of module it is. The value is a power of 2, which allows for bitwise operations to check if a module has a specific type and efficient storage in a using storage slot. The table below lists the module types and their corresponding values. A contract can be used as multiple module types.
+
+| Module type      | Value |
+|------------------|-------|
+| Plugin           | 1     |
+| Function Handler | 2     |
+| Hooks            | 4     |
+
 ## Plugins
 
 Plugins allow to add any arbitrary logic to an account such as recovery mechanisms, session keys, and automations.

--- a/modules/README.md
+++ b/modules/README.md
@@ -6,7 +6,7 @@ Modules extend the functionality of Accounts in different ways. Initial modules 
 
 ## Module Types
 
-Each module is assigned a value that represents the type of module it is. The value is a power of 2, which allows for bitwise operations to check if a module has a specific type and efficient storage in a using storage slot. The table below lists the module types and their corresponding values. A contract can be used as multiple module types.
+Each module is assigned a value that represents the type of module it is. The value is a power of 2, which permits bitwise operations and efficient storage of values. The table below lists the module types and their corresponding values. A contract can be used as multiple module types.
 
 | Module type      | Value |
 |------------------|-------|

--- a/registry/README.md
+++ b/registry/README.md
@@ -9,13 +9,13 @@ To facilitate these operations, the `Registry` MUST implement the following inte
 
 ```solidity
 interface SafeProtocolRegistry {
-    /** @param module Address of the module that should be checked
+    /**
+     * @param module Address of the module that should be checked
+     * @param data bytes32 providing more information about the module. The type of this parameter is bytes32 to provide the flexibility to the developers to interpret the value in the registry. For example, it can be moduleType and registry would then check if given address can be used as that type of module.
      * @return listedAt MUST return the block number when the module was listed in the registry (or 0 if not listed)
      * @return flaggedAt MUST return the block number when the module was listed in the flagged as faulty (or 0 if not flagged)
-     * @return moduleTypes uint8 indicating the types of module that the contract can be used as in the protocol.
-     *                     The value is a bitwise OR of the module types.
      */
-    function check(address module) external view returns (uint64 listedAt, uint64 flaggedAt, uint8 moduleTypes);
+    function check(address module, bytes32 data) external view returns (uint64 listedAt, uint64 flaggedAt);
 }
 ```
 

--- a/registry/README.md
+++ b/registry/README.md
@@ -9,10 +9,13 @@ To facilitate these operations, the `Registry` MUST implement the following inte
 
 ```solidity
 interface SafeProtocolRegistry {
-    /// @param integration Address of the integration that should be checked 
-    /// @return listedAt MUST return the block number when the integration was listed in the registry (or 0 if not listed)  
-    /// @return flaggedAt MUST return the block number when the integration was flagged as faulty (or 0 if not flagged)  
-    function check(address integration) external view returns (uint256 listedAt, uint256 flaggedAt);
+    /** @param module Address of the module that should be checked
+     * @return listedAt MUST return the block number when the module was listed in the registry (or 0 if not listed)
+     * @return flaggedAt MUST return the block number when the module was listed in the flagged as faulty (or 0 if not flagged)
+     * @return moduleTypes uint8 indicating the types of module that the contract can be used as in the protocol.
+     *                     The value is a bitwise OR of the module types.
+     */
+    function check(address module) external view returns (uint64 listedAt, uint64 flaggedAt, uint8 moduleTypes);
 }
 ```
 


### PR DESCRIPTION
Fixes #39 

Changes in PR:

- Define values for each module type
- Update registry's `check(...)` function as follows:
```solidity
function check(address module) external view returns (uint64 listedAt, uint64 flaggedAt, uint8 moduleTypes);
```

`moduleTypes` would be zero if input address is not listed.

Why is this change needed is explained in #39.
TLDR; Need information from registry on the type of module.

## Considerations while accepting this change as a solution:

If a contract is flagged in registry, it will be considered as malicious for all the types it is registered for. e.g., Suppose a contract is added in Registry as a Plugin and Function Handler and later gets flagged because of an issue in its behaviour as a plugin. Now, the `check(address)` would return `flaggedAt > 0` meaning it is flagged a malicious as a whole and not just for its plugin implementation. 

Why this approach? 
This approach is a simplified model that is easy to follow and implement with low cognitive complexity to understand how `flaggedAt` works.

`listedAt` would be the timestamp when module is first added in the registry.

Proposed implementation: https://github.com/safe-global/safe-core-protocol/pull/106

Other alternatives:

### a. Allow checking a module per type

In this case interface would look like as follows:

```solidity
function check(address module, uint8 moduleType) external view returns (uint64 listedAt, uint64 flaggedAt);
```

Here `moduleType` must be a power of 2 and function should revert for other values.
In this approach the contract returns values depending on both address of `module` and `moduleType`. 
- This provides flexibility to add a module with different types progressively and function would return accurate times when it was listed and flagged.
- Scenarios supported: A module can be flagged as Plugin and Procotol manager would block it. But, same module can be allowed as Function handler in the `Protocol`.




### b. Return values indicate individual module type, listedAt and flagged Info.

In this case interface would look like as follows:

```solidity
struct ModuleReturnInfo {
    uint64 listedAt;
    uint64 flaggedAt;
    uint8 moduleType;
}
function check(address module) external view returns (ModuleReturnInfo[] memory moduleRetrunInfoArray);
```

- This approach will lead to more gas usage

