### PR TITLE
Use consistent naming for plugins

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -54,7 +54,7 @@ To handle return data for `executeTransaction` (as it is an array of actions)
 
 As mentioned before it is required that both `SafeTransaction` and `SafeRootAccess` can be uniquely identified. An example where this is important is tooling related to indexing and querying information for the modules. For this purpose a `nonce` field is present in the structs, which allows to make the hash calculated for these is unique.
 
-**Important:** It is the responsibility of the integration (i.e. plug-in) to ensure that each of structs can be uniquely identified.
+**Important:** It is the responsibility of the integration (i.e. plugin) to ensure that each of structs can be uniquely identified.
 
 ## Flow Charts
 

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -41,14 +41,14 @@ Considering these criteria a good initial standard to follow is [EIP-712](https:
 
 TODO: we abuse the signing domain for context information, is there a better way?
 
-Note: `name` and `version` of the domain are used to identify the metadata type as the type hash is not easy to use with a simple query interface (i.e. `MetadataProvider`) due to nested hashing. An alternative would be that the domain object contains details about the part/context the metadata information is related to (i.e. a plug-in) and add type and version to the metadata object. 
+Note: `name` and `version` of the domain are used to identify the metadata type as the type hash is not easy to use with a simple query interface (i.e. `MetadataProvider`) due to nested hashing. An alternative would be that the domain object contains details about the part/context the metadata information is related to (i.e. a plugin) and add type and version to the metadata object. 
 
 ```solidity
 struct EIP712Domain {
     string name, // MUST be type name of the metadata (i.e. TransactionMetadata)
     string version, // MUST be version of the metadata (i.e. 1.0)
     uint256 chainId, // MUST be the chain where the integration related to this metadata resides
-    address verifyingContract, // MUST be integration address related to this metadata (i.e. plug-in address)
+    address verifyingContract, // MUST be integration address related to this metadata (i.e. plugin address)
 }
 ```
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -21,7 +21,7 @@ Plugins allow to add any arbitrary logic to an account such as recovery mechanis
 Plugins can trigger transactions on an `Account` via the `Manager`.
 
 ```solidity
-interface ISafeProtocolPlugIn {
+interface ISafeProtocolPlugin {
     function name() external view returns (string memory name);
 
     function version() external view returns (string memory version);


### PR DESCRIPTION
Fixes #22 
Changes in PR:

- Replace `ISafeProtocolPlugIn` with `ISafeProtocolPlugin`
- Replace `plug-in` with `plugin`