### PR TITLE
Use Relative Links to Spec Documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Safe{Core} Protocol is an open, modular framework to make smart accounts secure,
 
 The goal is to create a comprehensive system, designed to enhance the safety and flexibility of user interactions within the smart account ecosystem. The protocol provides a common framework for building additional tools, encourages the composition of various modules, and supports different types of smart accounts. In order to achieve interoperability and security, the protocol enforces a set of rules within the smart account ecosystem.
 
-[Read more on "Objectives" ->](/objective/README.md)
+[Read more on "Objectives" ->](./objective/README.md)
 
 ## Architecture
 
@@ -26,29 +26,29 @@ The architecture of the Safe{Core} Protocol is composed of several integral comp
 
 At the heart of the protocol is the `Manager`, ensuring adherence to the prescribed rules set by the `Registry`. The `Manager` serves as an intermediary layer coordinating communication and interactions between `Accounts` and `Modules`.
 
-[Read more on "Manager" ->](/manager/README.md)
+[Read more on "Manager" ->](./manager/README.md)
 
 ### Accounts
 
 `Accounts` are smart-contract based user accounts (or “smart accounts”). The Safe{Core} Protocol is account-agnostic, meaning that it is not tied to a specific account implementation.
 
-[Read more on "Accounts" ->](/accounts/README.md)
+[Read more on "Accounts" ->](./accounts/README.md)
 
 ### Modules
 
 `Modules` extend the functionality of `Accounts` in different ways. Initial modules are plugins, hooks, function handlers and signature validators, but additional modules can be added to the Safe{Core} Protocol at a later point.
 
-[Read more on "Modules" ->](/modules/README.md)
+[Read more on "Modules" ->](./modules/README.md)
 
 ### Registry
 
 The `Registry` plays a critical role in maintaining and enforcing standards and security guarantees. Only the `Modules` that adhere to these guidelines will be recognized and managed by the `Manager`.
 
-[Read more on "Registry" ->](/registry/README.md)
+[Read more on "Registry" ->](./registry/README.md)
 
 ### Metadata
 
 To provide a coherent context to the various parts and their interactions, the provision of `Metadata` is crucial. This information allows developers to append additional context to interactions, enhancing user understanding and interaction transparency.
 
 
-[Read more on "Metadata" ->](/metadata/README.md)
+[Read more on "Metadata" ->](./metadata/README.md)

--- a/accounts/README.md
+++ b/accounts/README.md
@@ -4,7 +4,7 @@ The Safe{Core} Protocol is designed to be **account agnostic**. This initial alp
 
 ## High-level overview
 
-The [Safe{Core} Protocol Manager](https://github.com/safe-global/safe-core-protocol-specs/blob/2bffd759dd12be5583594f302d97c35e0ab9fcf5/manager/README.md) contract is the main entity interacting with accounts and vice versa. The Manager expects accounts to implement a specific interface, described in this document.
+The [Safe{Core} Protocol Manager](../manager/README.md) contract is the main entity interacting with accounts and vice versa. The Manager expects accounts to implement a specific interface, described in this document.
 
 ## API Specification
 


### PR DESCRIPTION
Minor change to the existing specs to cleanup links to intra-spec documents to be relative.